### PR TITLE
Feature/update floater position

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ new FloatingFocus(containerElement); // Element is an optional parameter which d
 
 Define a default outline and outline-offset. Either of these values can be overruled per component:
 ```css
+// Hide all default focus states if a mouse is used, this is completely optional ofcourse
+*:focus {
+  outline: none;
+}
+
 // Default outline value, which will be applied to all elements receiving focus, this is a required step.
 .floating-focus-enabled *:focus {
   outline: dodgerblue solid 2px;
@@ -23,8 +28,8 @@ Define a default outline and outline-offset. Either of these values can be overr
 }
 
 // Give all buttons a green focus state instead of dodgerblue, this is optional in case it's needed.
-[type="button"]:focus {
-  outline: green dashed 1px;
+.floating-focus-enabled [type="button"]:focus {
+  outline-color: green;
   outline-offset: 4px;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ npm install @q42/floating-focus-a11y --save
 Import the package and instantiate the class on page load:
 ```javascript
 import FloatingFocus from '@q42/floating-focus-a11y';
-new FloatingFocus();
+new FloatingFocus(containerElement); // Element is an optional parameter which defaults to `document.body`
 ```
 
 Define a default outline and outline-offset. Either of these values can be overruled per component:

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -2,6 +2,8 @@ import './floating-focus.scss';
 import { isEqual, pick } from 'lodash';
 
 const MOVE_DURATION = 200;
+const HELPER_FADE_TIME = 800;
+const MONITOR_INTERVAL = 250;
 
 export default class FloatingFocus {
 	constructor(container = document.body) {
@@ -87,7 +89,7 @@ export default class FloatingFocus {
 		this.container.classList.add('floating-focus-enabled');
 		this.floater.classList.add('enabled');
 		clearInterval(this.monitorElementPositionInterval);
-		this.monitorElementPositionInterval = setInterval(this.monitorElementPosition, 250);
+		this.monitorElementPositionInterval = setInterval(this.monitorElementPosition, MONITOR_INTERVAL);
 	}
 
 	disableFloatingFocus() {
@@ -136,7 +138,7 @@ export default class FloatingFocus {
 		this.movingTimeout = setTimeout(() => this.floater.classList.remove('moving'), MOVE_DURATION);
 
 		clearTimeout(this.helperFadeTimeout);
-		this.helperFadeTimeout = setTimeout(() => this.floater.classList.remove('helper'), 800);
+		this.helperFadeTimeout = setTimeout(() => this.floater.classList.remove('helper'), HELPER_FADE_TIME);
 	}
 
 	handleBlur() {

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -30,7 +30,7 @@ export default class FloatingFocus {
 		this.handleFocus = this.handleFocus.bind(this);
 		this.handleBlur = this.handleBlur.bind(this);
 		this.handleScrollResize = this.handleScrollResize.bind(this);
-		this.checkElementPosition = this.monitorElementPosition.bind(this);
+		this.monitorElementPosition = this.monitorElementPosition.bind(this);
 	}
 
 	addKeydownEvents() {
@@ -192,9 +192,9 @@ export default class FloatingFocus {
 	monitorElementPosition() {
 		const newFloaterPosition = this.getFloaterPosition(this.target);
 
-		if (!isEqual( pick(floater.style, ['left','top','width','height']), newFloaterPosition )) {
+		if (!isEqual( pick(this.floater.style, ['left','top','width','height']), newFloaterPosition )) {
 			this.floater.classList.add('moving');
-			Object.assign(floater.style, newFloaterPosition);
+			Object.assign(this.floater.style, newFloaterPosition);
 			clearTimeout(this.movingTimeout);
 			this.movingTimeout = setTimeout(() => this.floater.classList.remove('moving'), MOVE_DURATION);
 		}

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -83,10 +83,6 @@ export default class FloatingFocus {
 		requestAnimationFrame(() => this.repositionElement(this.target, this.floater));
 	}
 
-	monitorElementPosition() {
-		this.repositionElement(this.target, this.floater, true);
-	}
-
 	enableFloatingFocus() {
 		this.container.classList.add('floating-focus-enabled');
 		this.floater.classList.add('enabled');
@@ -168,27 +164,33 @@ export default class FloatingFocus {
 		return number.toFixed(3).replace(/\.0+$/, '').replace(/\.([^0]+)0+$/, '.$1');
 	}
 
-	repositionElement(target, floater, moveAnimation = false) {
+	getFloaterPosition(target) {
 		const rect = target.getBoundingClientRect();
 
 		const { width, height } = rect;
 		const left = rect.left + rect.width / 2;
 		const top = rect.top + rect.height / 2;
 
-		const newFloaterStyle = {
+		return {
 			left: `${this.standardizeFloat(left)}px`,
 			top: `${this.standardizeFloat(top)}px`,
 			width: `${this.standardizeFloat(width)}px`,
 			height: `${this.standardizeFloat(height)}px`,
 		};
+	}
 
-		if (!isEqual( pick(floater.style, ['left','top','width','height']), newFloaterStyle )) {
-			if (moveAnimation) {
-				this.floater.classList.add('moving');
-				clearTimeout(this.movingTimeout);
-				this.movingTimeout = setTimeout(() => this.floater.classList.remove('moving'), MOVE_DURATION);
-			}
-			Object.assign(floater.style, newFloaterStyle);
+	monitorElementPosition() {
+		const newFloaterPosition = this.getFloaterPosition(this.target);
+
+		if (!isEqual( pick(floater.style, ['left','top','width','height']), newFloaterPosition )) {
+			this.floater.classList.add('moving');
+			Object.assign(floater.style, newFloaterPosition);
+			clearTimeout(this.movingTimeout);
+			this.movingTimeout = setTimeout(() => this.floater.classList.remove('moving'), MOVE_DURATION);
 		}
+	}
+
+	repositionElement(target, floater) {
+		Object.assign(floater.style, this.getFloaterPosition(target));
 	}
 }

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -178,8 +178,8 @@ export default class FloatingFocus {
 		const rect = target.getBoundingClientRect();
 
 		const { width, height } = rect;
-		const left = rect.left + rect.width / 2;
-		const top = rect.top + rect.height / 2;
+		const left = rect.left + width / 2;
+		const top = rect.top + height / 2;
 
 		return {
 			left: `${this.standardizeFloat(left)}px`,

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -190,6 +190,10 @@ export default class FloatingFocus {
 	}
 
 	monitorElementPosition() {
+		if (!this.target) {
+			return;
+		}
+
 		const newFloaterPosition = this.getFloaterPosition(this.target);
 
 		if (!isEqual( pick(this.floater.style, ['left','top','width','height']), newFloaterPosition )) {

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -1,4 +1,7 @@
 import './floating-focus.scss';
+import { isEqual, pick } from 'lodash';
+
+const MOVE_DURATION = 200;
 
 export default class FloatingFocus {
 	constructor(container = document.body) {
@@ -27,7 +30,7 @@ export default class FloatingFocus {
 		this.handleFocus = this.handleFocus.bind(this);
 		this.handleBlur = this.handleBlur.bind(this);
 		this.handleScrollResize = this.handleScrollResize.bind(this);
-		this.handleScrollResize = this.handleScrollResize.bind(this);
+		this.checkElementPosition = this.monitorElementPosition.bind(this);
 	}
 
 	addKeydownEvents() {
@@ -80,14 +83,21 @@ export default class FloatingFocus {
 		requestAnimationFrame(() => this.repositionElement(this.target, this.floater));
 	}
 
+	monitorElementPosition() {
+		this.repositionElement(this.target, this.floater, true);
+	}
+
 	enableFloatingFocus() {
 		this.container.classList.add('floating-focus-enabled');
 		this.floater.classList.add('enabled');
+		clearInterval(this.monitorElementPositionInterval);
+		this.monitorElementPositionInterval = setInterval(this.monitorElementPosition, 250);
 	}
 
 	disableFloatingFocus() {
 		this.container.classList.remove('floating-focus-enabled');
 		this.floater.classList.remove('enabled');
+		clearInterval(this.monitorElementPositionInterval);
 	}
 
 	handleFocus(e) {
@@ -118,7 +128,7 @@ export default class FloatingFocus {
 		this.target.classList.add('floating-focused');
 
 		clearTimeout(this.movingTimeout);
-		this.movingTimeout = setTimeout(() => this.floater.classList.remove('moving'), 200);
+		this.movingTimeout = setTimeout(() => this.floater.classList.remove('moving'), MOVE_DURATION);
 
 		clearTimeout(this.helperFadeTimeout);
 		this.helperFadeTimeout = setTimeout(() => this.floater.classList.remove('helper'), 800);
@@ -154,15 +164,31 @@ export default class FloatingFocus {
 		});
 	}
 
-	repositionElement(target, floater) {
+	standardizeFloat(number) {
+		return number.toFixed(3).replace(/\.0+$/, '').replace(/\.([^0]+)0+$/, '.$1');
+	}
+
+	repositionElement(target, floater, moveAnimation = false) {
 		const rect = target.getBoundingClientRect();
 
+		const { width, height } = rect;
 		const left = rect.left + rect.width / 2;
 		const top = rect.top + rect.height / 2;
 
-		floater.style.left = `${left}px`;
-		floater.style.top = `${top}px`;
-		floater.style.width = `${rect.width}px`;
-		floater.style.height = `${rect.height}px`;
+		const newFloaterStyle = {
+			left: `${this.standardizeFloat(left)}px`,
+			top: `${this.standardizeFloat(top)}px`,
+			width: `${this.standardizeFloat(width)}px`,
+			height: `${this.standardizeFloat(height)}px`,
+		};
+
+		if (!isEqual( pick(floater.style, ['left','top','width','height']), newFloaterStyle )) {
+			if (moveAnimation) {
+				this.floater.classList.add('moving');
+				clearTimeout(this.movingTimeout);
+				this.movingTimeout = setTimeout(() => this.floater.classList.remove('moving'), MOVE_DURATION);
+			}
+			Object.assign(floater.style, newFloaterStyle);
+		}
 	}
 }

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -171,7 +171,7 @@ export default class FloatingFocus {
 	}
 
 	standardizeFloat(number) {
-		return number.toFixed(3).replace(/\.0+$/, '').replace(/\.([^0]+)0+$/, '.$1');
+		return Math.round(parseFloat(number.toFixed(3) * 1000)) / 1000;
 	}
 
 	getFloaterPosition(target) {

--- a/src/floating-focus.spec.js
+++ b/src/floating-focus.spec.js
@@ -1,4 +1,5 @@
 import FloatingFocus from './floating-focus';
+// import * as FloatingFocusModule from './floating-focus';
 
 describe('Floating focus', () => {
 
@@ -293,6 +294,40 @@ describe('Floating focus', () => {
 		expect(floater.style.top).toBe(`${rect.top + rect.height / 2}px`);
 		expect(floater.style.width).toBe(`${rect.width}px`);
 		expect(floater.style.height).toBe(`${rect.height}px`);
+	});
+
+	it('Should automatically reposition the \'floater\' when the target element\'s position changes', async () => {
+		const floatingFocus = new FloatingFocus();
+		const target = document.createElement('div');
+		document.body.appendChild(target);
+
+		const rect = {
+			left: 42,
+			top: 84,
+			width: 42,
+			height: 128
+		};
+
+		target.getBoundingClientRect = jest.fn().mockImplementation(() => rect);
+
+		floatingFocus.handleKeyDown({keyCode: 9});
+		floatingFocus.enableFloatingFocus();
+		floatingFocus.handleFocus({target}, true);
+
+		expect(floatingFocus.floater.style.height).toBe(`${rect.height}px`);
+
+		await new Promise(resolve => setTimeout(resolve, 250));
+
+		expect(target.classList.contains('moving')).toBe(false);
+
+		rect.height = 100;
+
+		expect(floatingFocus.floater.style.height).not.toBe(`${rect.height}px`);
+
+		await new Promise(resolve => setTimeout(resolve, 250));
+
+		expect(floatingFocus.floater.style.height).toBe(`${rect.height}px`);
+		expect(floatingFocus.floater.classList.contains('moving')).toBe(true);
 	});
 
 	describe('standardizeFloat', () => {

--- a/src/floating-focus.spec.js
+++ b/src/floating-focus.spec.js
@@ -2,6 +2,10 @@ import FloatingFocus from './floating-focus';
 
 describe('Floating focus', () => {
 
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
 	afterEach(() => {
 		document.body.className = '';
 		document.body.innerHTML = '';
@@ -165,11 +169,11 @@ describe('Floating focus', () => {
 		expect(floatingFocus.target).toBe(target);
 		expect(floatingFocus.target.classList.contains('floating-focused')).toBe(true);
 
-		await new Promise(resolve => setTimeout(resolve, 200));
+		jest.advanceTimersByTime(200);
 
 		expect(floatingFocus.floater.classList.contains('moving')).toBe(false);
 
-		await new Promise(resolve => setTimeout(resolve, 800));
+		jest.advanceTimersByTime(800);
 
 		expect(floatingFocus.floater.classList.contains('helper')).toBe(false);
 	});
@@ -343,7 +347,7 @@ describe('Floating focus', () => {
 
 		expect(floatingFocus.floater.style.height).toBe(`${rect.height}px`);
 
-		await new Promise(resolve => setTimeout(resolve, 250));
+		jest.advanceTimersByTime(250);
 
 		expect(target.classList.contains('moving')).toBe(false);
 
@@ -351,7 +355,7 @@ describe('Floating focus', () => {
 
 		expect(floatingFocus.floater.style.height).not.toBe(`${rect.height}px`);
 
-		await new Promise(resolve => setTimeout(resolve, 250));
+		jest.advanceTimersByTime(250);
 
 		expect(floatingFocus.floater.style.height).toBe(`${rect.height}px`);
 		expect(floatingFocus.floater.classList.contains('moving')).toBe(true);

--- a/src/floating-focus.spec.js
+++ b/src/floating-focus.spec.js
@@ -299,21 +299,21 @@ describe('Floating focus', () => {
 		const floatingFocus = new FloatingFocus();
 
 		it('Should round to max 3 decimal places', () => {
-			expect(floatingFocus.standardizeFloat(1.3454)).toBe('1.345');
-			expect(floatingFocus.standardizeFloat(1.3456)).toBe('1.346');
-			expect(floatingFocus.standardizeFloat(1.3584368)).toBe('1.358');
-			expect(floatingFocus.standardizeFloat(1.345)).toBe('1.345');
-			expect(floatingFocus.standardizeFloat(1.34)).toBe('1.34');
-			expect(floatingFocus.standardizeFloat(1.3)).toBe('1.3');
-			expect(floatingFocus.standardizeFloat(1)).toBe('1');
+			expect(floatingFocus.standardizeFloat(1.3454)).toBe(1.345);
+			expect(floatingFocus.standardizeFloat(1.3456)).toBe(1.346);
+			expect(floatingFocus.standardizeFloat(1.3584368)).toBe(1.358);
+			expect(floatingFocus.standardizeFloat(1.345)).toBe(1.345);
+			expect(floatingFocus.standardizeFloat(1.34)).toBe(1.34);
+			expect(floatingFocus.standardizeFloat(1.3)).toBe(1.3);
+			expect(floatingFocus.standardizeFloat(1)).toBe(1);
 		});
 
 		it('Should cut off \'0\' decimal places', () => {
-			expect(floatingFocus.standardizeFloat(1.340)).toBe('1.34');
-			expect(floatingFocus.standardizeFloat(1.300)).toBe('1.3');
-			expect(floatingFocus.standardizeFloat(1.3000000)).toBe('1.3');
-			expect(floatingFocus.standardizeFloat(1.3000000)).toBe('1.3');
-			expect(floatingFocus.standardizeFloat(1.000)).toBe('1');
+			expect(floatingFocus.standardizeFloat(1.340)).toBe(1.34);
+			expect(floatingFocus.standardizeFloat(1.300)).toBe(1.3);
+			expect(floatingFocus.standardizeFloat(1.3000000)).toBe(1.3);
+			expect(floatingFocus.standardizeFloat(1.3000000)).toBe(1.3);
+			expect(floatingFocus.standardizeFloat(1.000)).toBe(1);
 		});
 	});
 

--- a/src/floating-focus.spec.js
+++ b/src/floating-focus.spec.js
@@ -295,4 +295,26 @@ describe('Floating focus', () => {
 		expect(floater.style.height).toBe(`${rect.height}px`);
 	});
 
+	describe('standardizeFloat', () => {
+		const floatingFocus = new FloatingFocus();
+
+		it('Should round to max 3 decimal places', () => {
+			expect(floatingFocus.standardizeFloat(1.3454)).toBe('1.345');
+			expect(floatingFocus.standardizeFloat(1.3456)).toBe('1.346');
+			expect(floatingFocus.standardizeFloat(1.3584368)).toBe('1.358');
+			expect(floatingFocus.standardizeFloat(1.345)).toBe('1.345');
+			expect(floatingFocus.standardizeFloat(1.34)).toBe('1.34');
+			expect(floatingFocus.standardizeFloat(1.3)).toBe('1.3');
+			expect(floatingFocus.standardizeFloat(1)).toBe('1');
+		});
+
+		it('Should cut off \'0\' decimal places', () => {
+			expect(floatingFocus.standardizeFloat(1.340)).toBe('1.34');
+			expect(floatingFocus.standardizeFloat(1.300)).toBe('1.3');
+			expect(floatingFocus.standardizeFloat(1.3000000)).toBe('1.3');
+			expect(floatingFocus.standardizeFloat(1.3000000)).toBe('1.3');
+			expect(floatingFocus.standardizeFloat(1.000)).toBe('1');
+		});
+	});
+
 });


### PR DESCRIPTION
This PR covers a specific case: the focus target changing position without the user's input.
Now whenever the floater is shown, an observer-type thing will run every 0.25 seconds and will move the floater if it notices that the target has moved.

I originally implemented this with way too many moving parts and the user having to define parents to be observed by a mutation observer etc, but after all as it is now I think is the most pragmatic way to go about this problem.