### PR TITLE
Force build script pre-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"build": "npm install --no-optional && npm run test && webpack --config webpack.prod.js",
 		"watch": "webpack --config webpack.dev.js",
 		"test": "jest --verbose --coverage",
-		"prepare": "npm run build"
+		"prepublishOnly": "npm run build"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 	"scripts": {
 		"build": "npm install --no-optional && npm run test && webpack --config webpack.prod.js",
 		"watch": "webpack --config webpack.dev.js",
-		"test": "jest --verbose --coverage"
+		"test": "jest --verbose --coverage",
+		"prepare": "npm run build"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.5.5",


### PR DESCRIPTION
The `prepublishOnly` script will (should (I haven't been able to test this yet as that would only happen when releasing a new version)) automatically trigger a build before `npm publish`ing.
The reason I thought of adding this now, is that version 1.2.0 was accidentally released without a `dist` folder, which naturally was going to happen eventually as it doesn't say anywhere that you should build first (: