### PR TITLE
Only publish the package not the repo

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-src/
-example/

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
 		"webpack-cli": "^3.3.6",
 		"webpack-merge": "^4.2.2"
 	},
-	"license": "MIT"
+	"license": "MIT",
+	"files": [
+		"dist/floating-focus.js"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
 	},
 	"license": "MIT",
 	"files": [
-		"dist/floating-focus.js"
+		"/dist"
 	]
 }


### PR DESCRIPTION
Currently all files are published in the NPM package. This PR whitelists `dist/floating-focus.js` so everything else won't be published to NPM.