### PR TITLE
Fix types for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
 declare class FloatingFocus {
 	constructor(container: Element);
 }
+
+export default FloatingFocus;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-export default class FloatingFocus {
-	constructor(container: Element = document.body) {}
+declare class FloatingFocus {
+	constructor(container: Element);
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare class FloatingFocus {
-	constructor(container: Element);
+	constructor(container?: Element);
 }
 
 export default FloatingFocus;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/Q42/FloatingFocus/issues"
 	},
 	"main": "dist/styled/index.js",
-	"typings": "index.d.ts",
+	"types": "index.d.ts",
 	"scripts": {
 		"build": "npm install --no-optional && npm run test && npm run buildOnly",
 		"buildOnly": "parallel-webpack --config webpack.prod.js",


### PR DESCRIPTION
### Description

Update types to make the package properly work with TypeScript projects.

### Test
1. Run `npm link` in a TS project.
2. Confirm TypeScript autocomplete of optional constructor parameter


### Related

Fixes #24 