### PR TITLE
Add back outline offset

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -73,10 +73,13 @@
 		label {
 			position: relative;
 			overflow: hidden;
-			outline-offset: 0 !important;
-			outline-color: orange !important;
-			outline-width: 2px !important;
-			outline-style: dashed !important;
+		}
+
+		.file-upload-label.focus {
+			outline-offset: 0;
+			outline-color: orange;
+			outline-width: 2px;
+			outline-style: dashed;
 		}
 
 		input[type="file"] {
@@ -112,7 +115,7 @@
 	<input type="text">
 	<input type="text">
 
-	<label id="file-upload-label">
+	<label id="file-upload-label" class="file-upload-label">
 		<input type="file" focus-target="file-upload-label"/>
 		Please upload a file
 	</label>

--- a/example/index.html
+++ b/example/index.html
@@ -73,6 +73,9 @@
 		label {
 			position: relative;
 			overflow: hidden;
+			outline-offset: 0 !important;
+			outline-color: orange !important;
+			outline-width: 2px !important;
 		}
 
 		input[type="file"] {

--- a/src/floating-focus.js
+++ b/src/floating-focus.js
@@ -176,6 +176,7 @@ export default class FloatingFocus {
 		const padding = targetStyle.outlineOffset || null;
 
 		Object.assign(floater.style, {
+			padding,
 			color: targetStyle.outlineColor,
 			borderWidth: targetStyle.outlineWidth,
 			borderBottomLeftRadius: this.getOffsetBorderRadius(targetStyle.borderBottomLeftRadius, padding),
@@ -213,7 +214,7 @@ export default class FloatingFocus {
 
 		const { left, top, width, height } = this.target.getBoundingClientRect();
 		const { left: leftPrev, top: topPrev, width: widthPrev, height: heightPrev } = this.previousTargetRect;
-		
+
 		if (left === leftPrev && top === topPrev && width === widthPrev && height === heightPrev) {
 			return;
 		}

--- a/src/floating-focus.spec.js
+++ b/src/floating-focus.spec.js
@@ -270,6 +270,7 @@ describe('Floating focus', () => {
 
 		floatingFocus.resolveTargetOutlineStyle(target, floater);
 
+		expect(floater.style.padding).toBe(targetStyle.outlineOffset);
 		expect(floater.style.color).toBe(targetStyle.outlineColor);
 		expect(floater.style.borderWidth).toBe(targetStyle.outlineWidth);
 		expect(floater.style.borderStyle).toBe(targetStyle.outlineStyle);


### PR DESCRIPTION
Another lil' bugfix. It seems in all the chaos of #28 a thing got lost, and that thing was changing the padding of the floater based on the focused element's style!
So this adds that back.