### PR TITLE
No transition when prefers-reduced-motion is set

### DIFF
--- a/src/floating-focus.scss
+++ b/src/floating-focus.scss
@@ -10,11 +10,15 @@
 	overflow: hidden;
 	z-index: 9999999999; // It should always be on top of everything, no matter what.
 
-	@media (prefers-reduced-motion: no-preference) {
+	&.moving {
+		transition-property: opacity, left, top, width, height, border-width, border-radius;
+		transition-duration: .2s, .1s, .1s, .1s, .1s, .1s, .1s;
+		transition-timing-function: linear, ease, ease, ease, ease, ease, ease;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
 		&.moving {
-			transition-property: opacity, left, top, width, height, border-width, border-radius;
-			transition-duration: .2s, .1s, .1s, .1s, .1s, .1s, .1s;
-			transition-timing-function: linear, ease, ease, ease, ease, ease, ease;
+			transition: none;
 		}
 	}
 

--- a/src/floating-focus.scss
+++ b/src/floating-focus.scss
@@ -10,10 +10,12 @@
 	overflow: hidden;
 	z-index: 9999999999; // It should always be on top of everything, no matter what.
 
-	&.moving {
-		transition-property: opacity, left, top, width, height, border-width, border-radius;
-		transition-duration: .2s, .1s, .1s, .1s, .1s, .1s, .1s;
-		transition-timing-function: linear, ease, ease, ease, ease, ease, ease;
+	@media (prefers-reduced-motion: no-preference) {
+		&.moving {
+			transition-property: opacity, left, top, width, height, border-width, border-radius;
+			transition-duration: .2s, .1s, .1s, .1s, .1s, .1s, .1s;
+			transition-timing-function: linear, ease, ease, ease, ease, ease, ease;
+		}
 	}
 
 	&.enabled.visible {


### PR DESCRIPTION
Voor een a11y tool is 't wel nice als die zich netjes aan reduced-motion settings houdt.

Werd gemeld door een gebruiker op Johan's [LinkedIn post](https://www.linkedin.com/feed/update/urn:li:activity:6763011278773518336?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A6763011278773518336%2C6763067218465968128%29&replyUrn=urn%3Ali%3Acomment%3A%28activity%3A6763011278773518336%2C6763132492758179840%29).